### PR TITLE
Promote to antigen plugin

### DIFF
--- a/git-escape-magic.plugin.zsh
+++ b/git-escape-magic.plugin.zsh
@@ -1,0 +1,3 @@
+source ${0:A:h}/git-escape-magic
+autoload -U git-escape-magic
+git-escape-magic


### PR DESCRIPTION
This will make the repo a valid Antigen plugin. 
To install and enable:

```
antigen bundle knu/zsh-git-escape-magic
antigen apply
```
